### PR TITLE
Create scheduler driver

### DIFF
--- a/code/drivers/CMakeLists.txt
+++ b/code/drivers/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(OpenVent_drivers)
 
 add_subdirectory(sensor)
+add_subdirectory(scheduler)

--- a/code/drivers/scheduler/CMakeLists.txt
+++ b/code/drivers/scheduler/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(OpenVent_drivers
+  PUBLIC
+    scheduler.c
+)

--- a/code/drivers/scheduler/scheduler.c
+++ b/code/drivers/scheduler/scheduler.c
@@ -1,0 +1,13 @@
+#include "scheduler/scheduler.h"
+#include "clock/clock.h"
+
+void scheduler_set_ms_callback(void(*callback)(void))
+{
+  clock_scheduler_stop();
+  clock_set_scheduler_ms_callback(callback);
+  if(callback)
+  {
+    // Only start the scheduler if we have a valid callback
+    clock_scheduler_start();
+  }
+}

--- a/code/drivers/scheduler/scheduler.h
+++ b/code/drivers/scheduler/scheduler.h
@@ -1,0 +1,21 @@
+#ifndef SCHEDULER_H
+#define SCHEDULER_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Set a callback to be executed every millisecond. Set to NULL to disable
+ *
+ * @param callback    The function pointer to call
+ */
+void scheduler_set_ms_callback(void(*callback)(void));
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* SCHEDULER_H */

--- a/code/hal/board/board_mk1.h
+++ b/code/hal/board/board_mk1.h
@@ -19,6 +19,7 @@
                             OCR1A = 499u
 #define SCHEDULER_START()   TIMSK1 |= (1u << OCIE1A)
 #define SCHEDULER_STOP()    TIMSK1 &= ~(1u << OCIE1A)
+#define SCHEDULER_INT_ISR   TIMER1_COMPA_vect
 
 // Motor PWM 125 kHz, phase correct
 #define MOTOR_PWM_TIM_CFG() TCCR0A = (1u << COM0B1) | (1u << WGM02) | (1u << WGM00)

--- a/code/hal/clock/clock.h
+++ b/code/hal/clock/clock.h
@@ -12,6 +12,27 @@ extern "C"
  */
 void clock_init(void);
 
+/**
+ * @brief Start the scheduler clock
+ *
+ * @param callback The function pointer to call
+ */
+void clock_scheduler_start(void);
+
+/**
+ * @brief Stop the scheduler clock
+ *
+ * @param callback The function pointer to call
+ */
+void clock_scheduler_stop(void);
+
+/**
+ * @brief Set a callback to be executed every millisecond
+ *
+ * @param callback The function pointer to call
+ */
+void clock_set_scheduler_ms_callback(void(*callback)(void));
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/code/hal/clock/clock_atmega328pb.c
+++ b/code/hal/clock/clock_atmega328pb.c
@@ -1,6 +1,10 @@
 #include "clock/clock.h"
 #include "board/board.h"
 
+#include <avr/interrupt.h>
+
+static void(*scheduler_callback)(void) = 0;
+
 // NOTE: in order to use the onboard 8MHz crystal, it is necessary to program fuses.  If this is not
 // performed, the internal RC oscillator is used.
 // CKSEL = 0xF
@@ -23,4 +27,27 @@ void clock_init(void)
 
   SCHEDULER_TIM_CFG();
   MOTOR_PWM_TIM_CFG();
+}
+
+void clock_scheduler_start(void)
+{
+  SCHEDULER_START();
+}
+
+void clock_scheduler_stop(void)
+{
+  SCHEDULER_STOP();
+}
+
+void clock_set_scheduler_ms_callback(void(*callback)(void))
+{
+  scheduler_callback = callback;
+}
+
+ISR(SCHEDULER_INT_ISR)
+{
+  if(scheduler_callback)
+  {
+    (*scheduler_callback)();
+  }
 }


### PR DESCRIPTION
This driver simply enables the scheduler interrupt once a non-null function pointer is provided and calls it every millisecond. When a null pointer is provided it disables the interrupt.