### PR TITLE
FPGA API and display driver

### DIFF
--- a/code/drivers/CMakeLists.txt
+++ b/code/drivers/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(OpenVent_drivers STATIC)
 
+add_subdirectory(fpga)
 add_subdirectory(sensor)

--- a/code/drivers/fpga/CMakeLists.txt
+++ b/code/drivers/fpga/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(OpenVent_drivers
+  PUBLIC
+    fpga.c
+)

--- a/code/drivers/fpga/CMakeLists.txt
+++ b/code/drivers/fpga/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(OpenVent_drivers
   PUBLIC
     fpga.c
+    display.c
 )

--- a/code/drivers/fpga/display.c
+++ b/code/drivers/fpga/display.c
@@ -117,22 +117,20 @@ void display_format_tidal_volume(uint16_t tidal_volume_ml)
   }
 }
 
-void display_format_peak_flow(uint16_t peak_flow_ml_per_sec)
+void display_format_peak_flow(uint16_t peak_flow_dl_per_min)
 {
   // Format display resolution and units: 0.1 l/min
   static uint16_t last_val = 0u;
 
-  if (peak_flow_ml_per_sec != last_val)
+  if (peak_flow_dl_per_min != last_val)
   {
-    last_val = peak_flow_ml_per_sec;
+    last_val = peak_flow_dl_per_min;
 
-    // Convert to decilitres per minute (i.e. display value without the decimal point)
-    uint16_t dl_per_min = peak_flow_ml_per_sec * 60u / 100u;
     char digits[DISP_PEAK_FLOW_LEN] = {'>', '1', '0', '0'};
 
-    if (dl_per_min < 1000u)
+    if (peak_flow_dl_per_min < 1000u)
     {
-      uint16_t remainder = dl_per_min;
+      uint16_t remainder = peak_flow_dl_per_min;
       digits[0] = remainder / 100u;
       remainder -= (digits[0] * 100u);
       digits[1] = remainder / 10u;
@@ -162,7 +160,7 @@ void display_format_respiration_rate(uint8_t breaths_per_min)
   {
     last_val = breaths_per_min;
 
-    char digits[DISP_RESP_RATE_LEN] = {'?', '?'};
+    char digits[DISP_RESP_RATE_LEN] = {'-', '-'};
 
     if (breaths_per_min < 100u)
     {
@@ -238,20 +236,20 @@ void display_format_battery_gauge(uint8_t charge_percent)
   s_display[DISP_BATTERY] = (char)CUSTOM_CHAR_BATTERY_INDICATOR;
 }
 
-void display_format_pressure_bar(uint16_t pressure_mmH2O, uint16_t peak_pressure_mmH2O)
+void display_format_pressure_bar(uint16_t pressure_cmH2O, uint16_t peak_pressure_cmH2O)
 {
   static uint16_t last_pressure = 0;
   static uint16_t last_peak = 0u;
 
   // Format pressure value
-  if (pressure_mmH2O != last_pressure)
+  if (pressure_cmH2O != last_pressure)
   {
-    char digits[DISP_PRESSURE_LEN] = {'?', '?'};
+    char digits[DISP_PRESSURE_LEN] = {'-', '-'};
 
-    if (pressure_mmH2O < 100u)
+    if (pressure_cmH2O < 100u)
     {
-      digits[0] = pressure_mmH2O / 10u;
-      digits[1] = pressure_mmH2O - (digits[0] * 10u);
+      digits[0] = pressure_cmH2O / 10u;
+      digits[1] = pressure_cmH2O - (digits[0] * 10u);
 
       for (size_t i = 0; i < DISP_RESP_RATE_LEN; i++)
       {
@@ -271,7 +269,7 @@ void display_format_pressure_bar(uint16_t pressure_mmH2O, uint16_t peak_pressure
   // }
 
   // Format pressure bar
-  if ((pressure_mmH2O != last_pressure) || (peak_pressure_mmH2O != last_peak))
+  if ((pressure_cmH2O != last_pressure) || (peak_pressure_cmH2O != last_peak))
   {
     char pressure_bar[DISP_PRESSURE_GAUGE_LEN];
 
@@ -279,13 +277,13 @@ void display_format_pressure_bar(uint16_t pressure_mmH2O, uint16_t peak_pressure
     memset(pressure_bar, ' ', sizeof(pressure_bar));
 
     // Calculate the incremental positions of the peak and instantaneous pressures
-    uint16_t peak_increments = peak_pressure_mmH2O / PRESSURE_BAR_MMH2O_INC;
+    uint16_t peak_increments = peak_pressure_cmH2O * 10u / PRESSURE_BAR_MMH2O_INC;
     if (peak_increments > PRESSURE_BAR_INCREMENTS)
     {
       peak_increments = PRESSURE_BAR_INCREMENTS;
     }
 
-    uint16_t pressure_increments = pressure_mmH2O / PRESSURE_BAR_MMH2O_INC;
+    uint16_t pressure_increments = pressure_cmH2O * 10u / PRESSURE_BAR_MMH2O_INC;
     if (pressure_increments > PRESSURE_BAR_INCREMENTS)
     {
       pressure_increments = PRESSURE_BAR_INCREMENTS;
@@ -348,8 +346,8 @@ void display_format_pressure_bar(uint16_t pressure_mmH2O, uint16_t peak_pressure
       }
     }
 
-    last_pressure = pressure_mmH2O;
-    last_peak = peak_pressure_mmH2O;
+    last_pressure = pressure_cmH2O;
+    last_peak = peak_pressure_cmH2O;
 
     strncpy(&s_display[DISP_PRESSURE_GAUGE], pressure_bar, DISP_PRESSURE_GAUGE_LEN);
     s_display_changed = true;

--- a/code/drivers/fpga/display.h
+++ b/code/drivers/fpga/display.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "fpga/fpga_api.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * Display formatting functions.  These will update the cached version of the display
+ */
+void display_format_tidal_volume(uint16_t tidal_volume_ml);
+void display_format_peak_flow(uint16_t peak_flow_ml_per_sec);
+void display_format_respiration_rate(uint8_t breaths_per_min);
+void display_format_percent_o2(uint8_t oxygen_percent);
+void display_format_battery_gauge(uint8_t charge_percent);
+void display_format_pressure_bar(uint16_t pressure_mmH2O, uint16_t peak_pressure_mmH2O);
+
+/**
+ * Check if the cached display has been changed (to avoid needing to call display_get)
+ *
+ * @return true Cached version of display has been updated
+ * @return false Cached version of display is unchanged
+ */
+bool display_has_changed(void);
+
+/**
+ * Format a message with a copy of the cached display (including custom characters)
+ *
+ * @param message_mcu_to_fpga_t* Pointer to the message
+ */
+void display_get(message_mcu_to_fpga_t* const message_to_format);

--- a/code/drivers/fpga/display.h
+++ b/code/drivers/fpga/display.h
@@ -8,11 +8,11 @@
  * Display formatting functions.  These will update the cached version of the display
  */
 void display_format_tidal_volume(uint16_t tidal_volume_ml);
-void display_format_peak_flow(uint16_t peak_flow_ml_per_sec);
+void display_format_peak_flow(uint16_t peak_flow_dl_per_min);
 void display_format_respiration_rate(uint8_t breaths_per_min);
 void display_format_percent_o2(uint8_t oxygen_percent);
 void display_format_battery_gauge(uint8_t charge_percent);
-void display_format_pressure_bar(uint16_t pressure_mmH2O, uint16_t peak_pressure_mmH2O);
+void display_format_pressure_bar(uint16_t pressure_cmH2O, uint16_t peak_pressure_cmH2O);
 
 /**
  * Check if the cached display has been changed (to avoid needing to call display_get)

--- a/code/drivers/fpga/fpga.c
+++ b/code/drivers/fpga/fpga.c
@@ -1,0 +1,3 @@
+#include "fpga.h"
+#include "fpga_api.h"
+#include "spi/spi.h"

--- a/code/drivers/fpga/fpga_api.h
+++ b/code/drivers/fpga/fpga_api.h
@@ -10,13 +10,13 @@ typedef uint16_t mcu_event_mask_t;
 typedef struct
 {
   fpga_event_mask_t event_mask;
-  uint16_t measured_flow_rate;    // ml per second
-  uint16_t measured_pressure;     // mmH2O
-  uint16_t plateau_pressure;      // target pressure set by user, mmH2O
+  uint16_t measured_flow_rate;    // decilitres per minute
+  uint16_t measured_pressure;     // cmH2O
+  uint16_t plateau_pressure;      // target pressure set by user, cmH2O
   uint16_t breath_rate;           // target breaths per minute
-  uint16_t inhale_period_cs;      // target length of expiration in centiseconds
+  uint16_t inhale_period_ds;      // target length of expiration in tenths of seconds
   uint16_t percent_oxygen;
-  uint16_t tidal_volume;          // ml
+  uint16_t tidal_volume;          // millilitres
   uint16_t padding_bytes;         // reserved bytes (note: value affects CRC calculation result)
   uint16_t heartbeat;
   uint32_t crc32;
@@ -82,21 +82,9 @@ enum mcu_event_bits
   // MCU_EVENT_RESERVED_10             = (1u << 10u),
   // MCU_EVENT_RESERVED_11             = (1u << 11u),
   // MCU_EVENT_RESERVED_12             = (1u << 12u),
-  MCU_EVENT_BATTERY_STATE_0         = (1u << 13u),
-  MCU_EVENT_BATTERY_STATE_1         = (1u << 14u),
-  MCU_EVENT_BATTERY_STATE_MASK      = (MCU_EVENT_BATTERY_STATE_1 | MCU_EVENT_BATTERY_STATE_0),
+  // MCU_EVENT_RESERVED_13             = (1u << 13u),
+  // MCU_EVENT_RESERVED_14             = (1u << 14u),
   // MCU_EVENT_RESERVED_15             = (1u << 15u)
-};
-
-/**
- * Bits 13-14 of enum mcu_event_bits
- */
-enum battery_status
-{
-  BATTERY_STATUS_MAINS        = 0u,                                                       // The battery is charging (or charged)
-  BATTERY_STATUS_DISCHARGING  = MCU_EVENT_BATTERY_STATE_0,                                // The battery is discharging
-  BATTERY_STATUS_LOW          = MCU_EVENT_BATTERY_STATE_1,                                // The battery requires charging urgently
-  BATTERY_STATUS_CRITICAL     = (MCU_EVENT_BATTERY_STATE_1 | MCU_EVENT_BATTERY_STATE_0),  // Battery power will be imminently withdrawn
 };
 
 /**

--- a/code/drivers/fpga/fpga_api.h
+++ b/code/drivers/fpga/fpga_api.h
@@ -14,10 +14,10 @@ typedef struct
   uint16_t measured_pressure;     // mmH2O
   uint16_t plateau_pressure;      // target pressure set by user, mmH2O
   uint16_t breath_rate;           // target breaths per minute
-  uint16_t exhale_inhale_ratio;   // target length of expiration x10 (unitless)
+  uint16_t inhale_period_cs;      // target length of expiration in centiseconds
   uint16_t percent_oxygen;
   uint16_t tidal_volume;          // ml
-  uint16_t padding_bytes;         // value only incidental in CRC calculation
+  uint16_t padding_bytes;         // reserved bytes (note: value affects CRC calculation result)
   uint16_t heartbeat;
   uint32_t crc32;
 } message_fpga_to_mcu_t;
@@ -35,42 +35,68 @@ typedef struct
 
 enum fpga_event_bits
 {
-  FPGA_EVENT_0 = (1u << 0u),
-  FPGA_EVENT_1 = (1u << 1u),
-  FPGA_EVENT_2 = (1u << 2u),
-  FPGA_EVENT_3 = (1u << 3u),
-  FPGA_EVENT_4 = (1u << 4u),
-  FPGA_EVENT_5 = (1u << 5u),
-  FPGA_EVENT_6 = (1u << 6u),
-  FPGA_EVENT_7 = (1u << 7u),
-  FPGA_EVENT_8 = (1u << 8u),
-  FPGA_EVENT_9 = (1u << 9u),
-  FPGA_EVENT_10 = (1u << 10u),
-  FPGA_EVENT_11 = (1u << 11u),
-  FPGA_EVENT_12 = (1u << 12u),
-  FPGA_EVENT_13 = (1u << 13u),
-  FPGA_EVENT_14 = (1u << 14u),
-  FPGA_EVENT_15 = (1u << 15u)
+  FPGA_EVENT_MODE_0                 = (1u << 0u),
+  FPGA_EVENT_MODE_1                 = (1u << 1u),
+  FPGA_EVENT_MODE_2                 = (1u << 2u),
+  FPGA_EVENT_MODE_MASK              = (FPGA_EVENT_MODE_2 | FPGA_EVENT_MODE_1 | FPGA_EVENT_MODE_0),
+  FPGA_EVENT_MOTOR_DISABLED         = (1u << 3u),    // The FPGA has disabled the motor
+  FPGA_EVENT_TIDAL_VOLUME_EXCEEDED  = (1u << 4u),    // The tidal volume limit is exceeded
+  FPGA_EVENT_ALARM_FAULT            = (1u << 5u),    // The FPGA requires the MCU to sound the alarm
+  // FPGA_EVENT_RESERVED_6             = (1u << 6u),
+  // FPGA_EVENT_RESERVED_7             = (1u << 7u),
+  // FPGA_EVENT_RESERVED_8             = (1u << 8u),
+  // FPGA_EVENT_RESERVED_9             = (1u << 9u),
+  // FPGA_EVENT_RESERVED_10            = (1u << 10u),
+  // FPGA_EVENT_RESERVED_11            = (1u << 11u),
+  // FPGA_EVENT_RESERVED_12            = (1u << 12u),
+  // FPGA_EVENT_RESERVED_13            = (1u << 13u),
+  // FPGA_EVENT_RESERVED_14            = (1u << 14u),
+  // FPGA_EVENT_RESERVED_15            = (1u << 15u)
+};
+
+/**
+ * Bits 0-2 of enum fpga_event_bits
+ */
+enum fpga_operating_mode
+{
+  FPGA_MODE_OFF                     = 0u,                                       // Power off request approved
+  FPGA_MODE_STANDBY                 = FPGA_EVENT_MODE_0,                        // Idle, power on
+  FPGA_MODE_PRESSURE_CONTROL        = FPGA_EVENT_MODE_1,                        // Use set points to control ventilation
+  FPGA_MODE_PRESSURE_SUPPORT        = (FPGA_EVENT_MODE_1 | FPGA_EVENT_MODE_0),  // Ventilation in response to patient demand
+  FPGA_MODE_STOP                    = FPGA_EVENT_MODE_2,                        // Used only during calibration
+  FPGA_MODE_RUN                     = (FPGA_EVENT_MODE_2 | FPGA_EVENT_MODE_0),  // Used only during calibration
 };
 
 enum mcu_event_bits
 {
-  MCU_EVENT_0 = (1u << 0u),
-  MCU_EVENT_1 = (1u << 1u),
-  MCU_EVENT_2 = (1u << 2u),
-  MCU_EVENT_3 = (1u << 3u),
-  MCU_EVENT_4 = (1u << 4u),
-  MCU_EVENT_5 = (1u << 5u),
-  MCU_EVENT_6 = (1u << 6u),
-  MCU_EVENT_7 = (1u << 7u),
-  MCU_EVENT_8 = (1u << 8u),
-  MCU_EVENT_9 = (1u << 9u),
-  MCU_EVENT_10 = (1u << 10u),
-  MCU_EVENT_11 = (1u << 11u),
-  MCU_EVENT_12 = (1u << 12u),
-  MCU_EVENT_13 = (1u << 13u),
-  MCU_EVENT_14 = (1u << 14u),
-  MCU_EVENT_15 = (1u << 15u)
+  MCU_EVENT_POWER_REQUEST_OFF       = (1u << 0u), // Request permission to remove power
+  MCU_EVENT_POWER_REQUEST_ON        = (1u << 1u), // Default - should be set except to request off
+  // MCU_EVENT_RESERVED_2              = (1u << 2u),
+  MCU_EVENT_RESET_MOTOR             = (1u << 3u), // Reenables the motor when disabled by the FPGA
+  MCU_EVENT_ACTUATOR_FAULT          = (1u << 4u), // The actuator is stuck
+  MCU_EVENT_BAG_FAULT               = (1u << 5u), // The bag is damaged
+  MCU_EVENT_BLOCKAGE_FAULT          = (1u << 6u), // There is a blockage in the airway
+  MCU_EVENT_LEAK_FAULT              = (1u << 7u), // There is a leak in the airway
+  MCU_EVENT_LIMIT_SWITCH_FAULT      = (1u << 8u), // The primary limit switch is not responding
+  // MCU_EVENT_RESERVED_9              = (1u << 9u),
+  // MCU_EVENT_RESERVED_10             = (1u << 10u),
+  // MCU_EVENT_RESERVED_11             = (1u << 11u),
+  // MCU_EVENT_RESERVED_12             = (1u << 12u),
+  MCU_EVENT_BATTERY_STATE_0         = (1u << 13u),
+  MCU_EVENT_BATTERY_STATE_1         = (1u << 14u),
+  MCU_EVENT_BATTERY_STATE_MASK      = (MCU_EVENT_BATTERY_STATE_1 | MCU_EVENT_BATTERY_STATE_0),
+  // MCU_EVENT_RESERVED_15             = (1u << 15u)
+};
+
+/**
+ * Bits 13-14 of enum mcu_event_bits
+ */
+enum battery_status
+{
+  BATTERY_STATUS_MAINS        = 0u,                                                       // The battery is charging (or charged)
+  BATTERY_STATUS_DISCHARGING  = MCU_EVENT_BATTERY_STATE_0,                                // The battery is discharging
+  BATTERY_STATUS_LOW          = MCU_EVENT_BATTERY_STATE_1,                                // The battery requires charging urgently
+  BATTERY_STATUS_CRITICAL     = (MCU_EVENT_BATTERY_STATE_1 | MCU_EVENT_BATTERY_STATE_0),  // Battery power will be imminently withdrawn
 };
 
 /**
@@ -83,8 +109,7 @@ enum mcu_event_bits
 inline void fpga_heartbeat_calculate(
   message_mcu_to_fpga_t* const message_to_format, uint16_t received_heartbeat)
 {
-  // TODO - implementation to be confirmed - probably bitwise NOT as below
-  message_to_format->heartbeat = ~received_heartbeat;
+  message_to_format->heartbeat = ~received_heartbeat + 1u;
 }
 
 /**
@@ -105,7 +130,8 @@ void fpga_display_format_pressure_bar(int16_t pressure_mmH2O, uint16_t peak_pres
  */
 bool fpga_display_has_changed(void);
 
-/** Format a message with a copy of the cached display (including custom characters)
+/**
+ * Format a message with a copy of the cached display (including custom characters)
  *
  * @param message_mcu_to_fpga_t* Pointer to the message
  */

--- a/code/drivers/fpga/fpga_api.h
+++ b/code/drivers/fpga/fpga_api.h
@@ -1,0 +1,114 @@
+#ifndef FPGA_API_H
+#define FPGA_API_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef uint16_t fpga_event_mask_t;
+typedef uint16_t mcu_event_mask_t;
+
+typedef struct
+{
+  fpga_event_mask_t event_mask;
+  uint16_t measured_flow_rate;    // ml per second
+  uint16_t measured_pressure;     // mmH2O
+  uint16_t plateau_pressure;      // target pressure set by user, mmH2O
+  uint16_t breath_rate;           // target breaths per minute
+  uint16_t exhale_inhale_ratio;   // target length of expiration x10 (unitless)
+  uint16_t percent_oxygen;
+  uint16_t tidal_volume;          // ml
+  uint16_t padding_bytes;         // value only incidental in CRC calculation
+  uint16_t heartbeat;
+  uint32_t crc32;
+} message_fpga_to_mcu_t;
+
+typedef struct
+{
+  char display_lines[32];
+  uint64_t battery_indicator;
+  uint64_t pressure_bar_edge;
+  uint64_t pressure_bar_peak;
+  mcu_event_mask_t event_mask;
+  uint16_t heartbeat;
+  uint32_t crc32;
+} message_mcu_to_fpga_t;
+
+enum fpga_event_bits
+{
+  FPGA_EVENT_0 = (1u << 0u),
+  FPGA_EVENT_1 = (1u << 1u),
+  FPGA_EVENT_2 = (1u << 2u),
+  FPGA_EVENT_3 = (1u << 3u),
+  FPGA_EVENT_4 = (1u << 4u),
+  FPGA_EVENT_5 = (1u << 5u),
+  FPGA_EVENT_6 = (1u << 6u),
+  FPGA_EVENT_7 = (1u << 7u),
+  FPGA_EVENT_8 = (1u << 8u),
+  FPGA_EVENT_9 = (1u << 9u),
+  FPGA_EVENT_10 = (1u << 10u),
+  FPGA_EVENT_11 = (1u << 11u),
+  FPGA_EVENT_12 = (1u << 12u),
+  FPGA_EVENT_13 = (1u << 13u),
+  FPGA_EVENT_14 = (1u << 14u),
+  FPGA_EVENT_15 = (1u << 15u)
+};
+
+enum mcu_event_bits
+{
+  MCU_EVENT_0 = (1u << 0u),
+  MCU_EVENT_1 = (1u << 1u),
+  MCU_EVENT_2 = (1u << 2u),
+  MCU_EVENT_3 = (1u << 3u),
+  MCU_EVENT_4 = (1u << 4u),
+  MCU_EVENT_5 = (1u << 5u),
+  MCU_EVENT_6 = (1u << 6u),
+  MCU_EVENT_7 = (1u << 7u),
+  MCU_EVENT_8 = (1u << 8u),
+  MCU_EVENT_9 = (1u << 9u),
+  MCU_EVENT_10 = (1u << 10u),
+  MCU_EVENT_11 = (1u << 11u),
+  MCU_EVENT_12 = (1u << 12u),
+  MCU_EVENT_13 = (1u << 13u),
+  MCU_EVENT_14 = (1u << 14u),
+  MCU_EVENT_15 = (1u << 15u)
+};
+
+/**
+ * Calculate the heartbeat word required to prevent the FPGA resetting the MCU and insert it into
+ * the message
+ *
+ * @param message_to_format Pointer to the message that will be set to the FPGA
+ * @param received_heartbeat Heartbeat extracted from the last message received from the FPGA
+ */
+inline void fpga_heartbeat_calculate(
+  message_mcu_to_fpga_t* const message_to_format, uint16_t received_heartbeat)
+{
+  // TODO - implementation to be confirmed - probably bitwise NOT as below
+  message_to_format->heartbeat = ~received_heartbeat;
+}
+
+/**
+ * Display formatting functions.  These will update the cached version of the display
+ */
+void fpga_display_format_tidal_volume(uint16_t tidal_volume_ml);
+void fpga_display_format_peak_flow(uint16_t peak_flow_ml_per_sec);
+void fpga_display_format_respiration_rate(uint8_t breaths_per_min);
+void fpga_display_format_percent_o2(uint8_t oxygen_ppthou);
+void fpga_display_format_battery_gauge(uint8_t charge_percent);
+void fpga_display_format_pressure_bar(int16_t pressure_mmH2O, uint16_t peak_pressure_mmH2O);
+
+/**
+ * Check if the cached display has been changed (to avoid needing to call display_get)
+ *
+ * @return true Cached version of display has been updated
+ * @return false Cached version of display is unchanged
+ */
+bool fpga_display_has_changed(void);
+
+/** Format a message with a copy of the cached display (including custom characters)
+ *
+ * @param message_mcu_to_fpga_t* Pointer to the message
+ */
+void fpga_display_get(message_mcu_to_fpga_t* const message_to_format);
+
+#endif /* FPGA_API_H */

--- a/code/drivers/fpga/fpga_api.h
+++ b/code/drivers/fpga/fpga_api.h
@@ -112,29 +112,4 @@ inline void fpga_heartbeat_calculate(
   message_to_format->heartbeat = ~received_heartbeat + 1u;
 }
 
-/**
- * Display formatting functions.  These will update the cached version of the display
- */
-void fpga_display_format_tidal_volume(uint16_t tidal_volume_ml);
-void fpga_display_format_peak_flow(uint16_t peak_flow_ml_per_sec);
-void fpga_display_format_respiration_rate(uint8_t breaths_per_min);
-void fpga_display_format_percent_o2(uint8_t oxygen_ppthou);
-void fpga_display_format_battery_gauge(uint8_t charge_percent);
-void fpga_display_format_pressure_bar(int16_t pressure_mmH2O, uint16_t peak_pressure_mmH2O);
-
-/**
- * Check if the cached display has been changed (to avoid needing to call display_get)
- *
- * @return true Cached version of display has been updated
- * @return false Cached version of display is unchanged
- */
-bool fpga_display_has_changed(void);
-
-/**
- * Format a message with a copy of the cached display (including custom characters)
- *
- * @param message_mcu_to_fpga_t* Pointer to the message
- */
-void fpga_display_get(message_mcu_to_fpga_t* const message_to_format);
-
 #endif /* FPGA_API_H */

--- a/code/drivers/fpga/fpga_display.c
+++ b/code/drivers/fpga/fpga_display.c
@@ -1,0 +1,463 @@
+#include "fpga_api.h"
+#include <string.h>
+
+#define BATTERY_INDICATOR_OUTLINE \
+  (uint64_t)( 0b01110 << 56u | \
+              0b11111 << 48u | \
+              0b10001 << 40u | \
+              0b10001 << 32u | \
+              0b10001 << 24u | \
+              0b10001 << 16u | \
+              0b10001 << 8u  | \
+              0b11111 )
+
+#define BATTERY_INDICATOR_EDGE (0b01110)
+
+/**
+ * This just creates a single vertical line down the left side.  To adjust the position,
+ * right shift up to 4.  To create a solid block, OR the result in a loop
+ */
+#define PRESSURE_BAR_EDGE \
+  (uint64_t)( 0b10000 << 56u | \
+              0b10000 << 48u | \
+              0b10000 << 40u | \
+              0b10000 << 32u | \
+              0b10000 << 24u | \
+              0b10000 << 16u | \
+              0b10000 << 8u  | \
+              0b10000 )
+
+#define FULL_BLOCK (219u)
+
+enum display_index
+{
+  // TOP LINE
+  DISP_TIDAL_VOL      = 0,
+  DISP_TIDAL_VOL_LEN    = 3,
+  DISP_PEAK_FLOW      = 4,
+  DISP_PEAK_FLOW_LEN    = 4,
+  DISP_RESP_RATE      = 9,
+  DISP_RESP_RATE_LEN    = 2,
+  DISP_PERCENT_O2     = 12,
+  DISP_PERCENT_LEN      = 3,
+  DISP_BATTERY        = 15,
+  DISP_BATTERY_LEN      = 1,
+  // BOTTOM LINE
+  DISP_PRESSURE_NEG   = 16,
+  DISP_PRESSURE_NEG_LEN = 2,
+  DISP_PRESSURE_POS   = 18,
+  DISP_PRESSURE_POS_LEN = 14,
+
+  DISP_LEN            = 32
+};
+
+#define PRESSURE_BAR_MMH2O_MAX      (450)
+#define PRESSURE_BAR_MMH2O_MIN      (-67)
+#define PRESSURE_BAR_SUB_INCREMENTS (3) // line left, line centre, line right
+#define PRESSURE_BAR_POS_INCREMENTS (DISP_PRESSURE_POS_LEN * PRESSURE_BAR_SUB_INCREMENTS)
+#define PRESSURE_BAR_NEG_INCREMENTS (DISP_PRESSURE_NEG_LEN * PRESSURE_BAR_SUB_INCREMENTS)
+#define PRESSURE_BAR_MMH2O_INC      (PRESSURE_BAR_MMH2O_MAX / PRESSURE_BAR_POS_INCREMENTS)
+
+/**
+ * These are the character addresses in the display for the custom characters.
+ * Use these as the ascii code, e.g. (char)CUSTOM_CHAR_PRESSURE_BAR_EDGE.
+ */
+enum custom_char
+{
+  CUSTOM_CHAR_BATTERY_INDICATOR = 0,
+  CUSTOM_CHAR_PRESSURE_BAR_EDGE = 1,
+  CUSTOM_CHAR_PRESSURE_BAR_PEAK = 2,
+  CUSTOM_CHAR_COUNT
+};
+
+/**
+ * Createable custom character definitions
+ *
+ */
+enum display_char
+{
+  DISPLAY_CHAR_PEAK_PRESSURE_1, // Single vertical line to left
+  DISPLAY_CHAR_PEAK_PRESSURE_2, // Single vertical line in centre
+  DISPLAY_CHAR_PEAK_PRESSURE_3, // Single vertical line to right
+  DISPLAY_CHAR_PRESSURE_1,      // Single vertical line to left
+  DISPLAY_CHAR_PRESSURE_2,      // Half-width block to left
+  DISPLAY_CHAR_PRESSURE_3,      // Full block
+  DISPLAY_CHAR_BATTERY_0,       // Empty battery outline
+  DISPLAY_CHAR_BATTERY_20,      // Partly filled battery outline
+  DISPLAY_CHAR_BATTERY_40,      // Partly filled battery outline
+  DISPLAY_CHAR_BATTERY_60,      // Partly filled battery outline
+  DISPLAY_CHAR_BATTERY_80,      // Partly filled battery outline
+  DISPLAY_CHAR_BATTERY_100      // Full battery outline
+};
+
+uint64_t s_custom_chars[CUSTOM_CHAR_COUNT] = {0u};
+char s_display[DISP_LEN] = {0u};
+bool s_display_changed = false;
+
+/**
+ * Replace a cached custom_char
+ *
+ * @param char_to_create enum display_char
+ */
+static void make_custom_char(enum display_char char_to_create)
+{
+  switch (char_to_create)
+  {
+    case DISPLAY_CHAR_PEAK_PRESSURE_1:
+    case DISPLAY_CHAR_PEAK_PRESSURE_2:
+    case DISPLAY_CHAR_PEAK_PRESSURE_3:
+    {
+      uint32_t shifts = (char_to_create - DISPLAY_CHAR_PEAK_PRESSURE_1) * 2u;
+      uint64_t return_char = PRESSURE_BAR_EDGE;
+
+      while (shifts > 0)
+      {
+        return_char |= (PRESSURE_BAR_EDGE >> shifts);
+      }
+
+      if (s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK] != return_char)
+      {
+        s_display_changed = true;
+        s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK] = return_char;
+      }
+      break;
+    }
+
+
+    case DISPLAY_CHAR_PRESSURE_1:
+    case DISPLAY_CHAR_PRESSURE_2:
+    case DISPLAY_CHAR_PRESSURE_3:
+    {
+      uint32_t shifts = (char_to_create - DISPLAY_CHAR_PRESSURE_1) * 2u;
+      uint64_t return_char = PRESSURE_BAR_EDGE;
+
+      while (shifts > 0)
+      {
+        return_char |= (PRESSURE_BAR_EDGE >> shifts);
+      }
+
+      if (s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE] != return_char)
+      {
+        s_display_changed = true;
+        s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE] = return_char;
+      }
+      break;
+    }
+
+    case DISPLAY_CHAR_BATTERY_0:
+    case DISPLAY_CHAR_BATTERY_20:
+    case DISPLAY_CHAR_BATTERY_40:
+    case DISPLAY_CHAR_BATTERY_60:
+    case DISPLAY_CHAR_BATTERY_80:
+    case DISPLAY_CHAR_BATTERY_100:
+    {
+      uint32_t shifts = char_to_create - DISPLAY_CHAR_BATTERY_0;
+      uint64_t return_char = BATTERY_INDICATOR_OUTLINE;
+      uint64_t shift_char = BATTERY_INDICATOR_EDGE;
+
+      while (shifts > 0)
+      {
+        return_char |= (shift_char << 8u);
+      }
+
+      if (s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR] != return_char)
+      {
+        s_display_changed = true;
+        s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR] = return_char;
+      }
+      break;
+    }
+  }
+}
+
+void fpga_display_format_tidal_volume(uint16_t tidal_volume_ml)
+{
+  static uint16_t last_val = 0u;
+
+  if (tidal_volume_ml != last_val)
+  {
+    char digits[DISP_TIDAL_VOL_LEN] = {'1', 'k', '+'};
+
+    if (tidal_volume_ml <= 999u)
+    {
+      uint16_t remainder = tidal_volume_ml;
+      digits[0] = remainder / 100u;
+      remainder -= (digits[0] * 100u);
+      digits[1] = remainder / 10u;
+      digits[2] = remainder - (digits[1] * 10u);
+
+      for (size_t i = 0; i < DISP_TIDAL_VOL_LEN; i++)
+      {
+        digits[i] += '0';
+      }
+    }
+
+    strncpy(&s_display[DISP_TIDAL_VOL], digits, DISP_TIDAL_VOL_LEN);
+    s_display_changed = true;
+  }
+}
+
+void fpga_display_format_peak_flow(uint16_t peak_flow_ml_per_sec)
+{
+  static uint16_t last_val = 0u;
+
+  if (peak_flow_ml_per_sec != last_val)
+  {
+    uint32_t litres_per_600s = peak_flow_ml_per_sec * 600u / 1000u;
+    char digits[DISP_PEAK_FLOW_LEN] = {0u};
+
+    if (litres_per_600s >= 1000u)
+    {
+      // Integer display only - round up
+      litres_per_600s = litres_per_600s + 5u;
+    }
+
+    uint16_t remainder = litres_per_600s;
+    digits[0] = remainder / 100u;
+    remainder -= (digits[0] * 100u);
+    digits[1] = remainder / 10u;
+    digits[2] = remainder - (digits[1] * 10u);
+
+    for (size_t i = 0; i < (DISP_PEAK_FLOW_LEN - 1u); i++)
+    {
+      digits[i] += '0';
+    }
+
+    if (litres_per_600s >= 1000u)
+    {
+      // Just append a decimal point
+      digits[3] = '.';
+    }
+    else
+    {
+      // 'Divide' by 10 by inserting a decimal point before the final digit
+      digits[3] = digits[2];
+      digits[2] = '.';
+    }
+
+    strncpy(&s_display[DISP_PEAK_FLOW], digits, DISP_PEAK_FLOW_LEN);
+    s_display_changed = true;
+  }
+}
+
+void fpga_display_format_respiration_rate(uint8_t breaths_per_min)
+{
+  static uint8_t last_val = 0u;
+
+  if (breaths_per_min != last_val)
+  {
+    char digits[DISP_RESP_RATE_LEN] = {'?', '?'};
+
+    if (breaths_per_min <= 99u)
+    {
+      digits[0] = breaths_per_min / 10u;
+      digits[1] = breaths_per_min - (digits[0] * 10u);
+
+      for (size_t i = 0; i < DISP_RESP_RATE_LEN; i++)
+      {
+        digits[i] += '0';
+      }
+    }
+
+    strncpy(&s_display[DISP_RESP_RATE], digits, DISP_RESP_RATE_LEN);
+    s_display_changed = true;
+  }
+}
+
+void fpga_display_format_percent_o2(uint8_t oxygen_ppthou)
+{
+  static uint8_t last_val = 0u;
+
+  if (oxygen_ppthou != last_val)
+  {
+    char digits[DISP_PERCENT_LEN];
+
+    if (oxygen_ppthou >= 100u)
+    {
+      // Integer display only - round up
+      uint32_t percent_val = (oxygen_ppthou + 5u) / 10u;
+
+      // int1 is now the value in percent
+      digits[0] = percent_val / 10u;
+      digits[1] = percent_val - (int1 * 10u);
+
+      digits[0] += '0';
+      digits[1] += '0';
+      digits[2] = '.'
+    }
+    else
+    {
+      // Decimal display
+      digits[0] = oxygen_ppthou / 10u;
+      digits[2] = oxygen_ppthou - (int1 * 10u);
+
+      digits[0] += '0';
+      digits[1] = '.';
+      digits[2] += '0';
+    }
+
+    strncpy(&s_display[DISP_PERCENT_O2], digits, DISP_PERCENT_LEN);
+    s_display_changed = true;
+  }
+}
+
+void fpga_display_format_battery_gauge(uint8_t charge_percent)
+{
+  if (charge_percent > 80u)
+  {
+    make_custom_char(DISPLAY_CHAR_BATTERY_100);
+  }
+  else if (charge_percent > 60u)
+  {
+    make_custom_char(DISPLAY_CHAR_BATTERY_80);
+  }
+  else if (charge_percent > 40u)
+  {
+    make_custom_char(DISPLAY_CHAR_BATTERY_60);
+  }
+  else if (charge_percent > 20u)
+  {
+    make_custom_char(DISPLAY_CHAR_BATTERY_40);
+  }
+  else if (charge_percent > 5u)
+  {
+    make_custom_char(DISPLAY_CHAR_BATTERY_20);
+  }
+  else
+  {
+    make_custom_char(DISPLAY_CHAR_BATTERY_0);
+  }
+
+  // Ensure the indicator shows on the display if overwritten
+  s_display[DISP_BATTERY] = (char)CUSTOM_CHAR_BATTERY_INDICATOR;
+}
+
+void fpga_display_format_pressure_bar(int16_t pressure_mmH2O, uint16_t peak_pressure_mmH2O)
+{
+  static int16_t last_pressure = 0;
+  static uint16_t last_peak = 0u;
+
+  if ((pressure_mmH2O != last_pressure) || (peak_pressure_mmH2O != last_peak))
+  {
+    size_t index;
+    char pressure_bar[DISP_PRESSURE_NEG_LEN + DISP_PRESSURE_POS_LEN];
+
+    // Start with a gauge
+    memset(pressure_bar, ' ', sizeof(pressure_bar));
+
+    // Calculate the incremental positions of the peak and instantaneous pressures
+    int8_t peak_increments = peak_pressure_mmH2O / PRESSURE_BAR_MMH2O_INC;
+    if (peak_increments > PRESSURE_BAR_POS_INCREMENTS)
+    {
+      peak_increments = PRESSURE_BAR_POS_INCREMENTS;
+    }
+
+    int8_t pressure_increments = pressure_mmH2O / PRESSURE_BAR_MMH2O_INC;
+    if (pressure_increments > PRESSURE_BAR_POS_INCREMENTS)
+    {
+      pressure_increments = PRESSURE_BAR_POS_INCREMENTS;
+    }
+    else if (pressure_increments < -PRESSURE_BAR_NEG_INCREMENTS)
+    {
+      pressure_increments = -PRESSURE_BAR_NEG_INCREMENTS;
+    }
+
+    // Build the display block by block
+    if (pressure_increments >= 0)
+    {
+      index = 2u;
+      while (pressure_increments >= PRESSURE_BAR_SUB_INCREMENTS)
+      {
+        pressure_bar[index] = (char)FULL_BLOCK;
+        pressure_increments -= PRESSURE_BAR_SUB_INCREMENTS;
+        peak_increments -= PRESSURE_BAR_SUB_INCREMENTS;
+        index++;
+      }
+
+      if (pressure_increments > 0)
+      {
+        // Cap off the gauge with a partial block
+        pressure_bar[index] = (char)CUSTOM_CHAR_PRESSURE_BAR_EDGE;
+      }
+    }
+    else
+    {
+      index = 1u;
+      while (pressure_increments <= -PRESSURE_BAR_SUB_INCREMENTS)
+      {
+        pressure_bar[index] = (char)FULL_BLOCK;
+        pressure_increments += PRESSURE_BAR_SUB_INCREMENTS;
+        index--;
+      }
+
+      if (pressure_increments < 0)
+      {
+        // Cap off the gauge with a partial block
+        pressure_bar[index] = (char)CUSTOM_CHAR_PRESSURE_BAR_EDGE;
+      }
+
+      // Peak pressure mark is always positive, so reset index to the zero position
+      index = 2u;
+    }
+
+    // Make the appropriate characters based on the remainders
+    make_custom_char(DISPLAY_CHAR_PEAK_PRESSURE_1 + peak_increments);
+    if (pressure_increments >= 0)
+    {
+      make_custom_char(DISPLAY_CHAR_PRESSURE_1 + pressure_increments);
+
+      if (peak_increments < PRESSURE_BAR_SUB_INCREMENTS)
+      {
+        // Characters overlap, so we need to OR them and store in the instantaneous character
+        // position (because the peak character doesn't change as much)
+        s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE] |=
+          s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK];
+
+        peak_increments = 0;
+      }
+    }
+    else
+    {
+      make_custom_char(DISPLAY_CHAR_PRESSURE_1 - pressure_increments);
+
+      // Invert
+      s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE] = ~s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE];
+    }
+
+    // Add peak pressure mark if still required
+    if (peak_increments > 0)
+    {
+      while (peak_increments >= PRESSURE_BAR_SUB_INCREMENTS)
+      {
+        peak_increments -= PRESSURE_BAR_SUB_INCREMENTS;
+        index++;
+      }
+
+      // Cap off the gauge with the peak line
+      pressure_bar[index] = (char)CUSTOM_CHAR_PRESSURE_BAR_PEAK;
+    }
+
+    strncpy(
+      &s_display[DISP_PRESSURE_NEG], pressure_bar, (DISP_PRESSURE_NEG_LEN + DISP_PRESSURE_POS_LEN));
+    s_display_changed = true;
+  }
+}
+
+bool fpga_display_has_changed(void)
+{
+  return s_display_changed;
+}
+
+void fpga_display_get(message_mcu_to_fpga_t* const message_to_format)
+{
+  if (!message_to_format)
+  {
+    return;
+  }
+
+  memcpy(message_to_format->display_lines, s_display, sizeof(s_display));
+  message_to_format->battery_indicator = s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR];
+  message_to_format->pressure_bar_edge = s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE];
+  message_to_format->pressure_bar_peak = s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK];
+  s_display_changed = false;
+}

--- a/code/drivers/fpga/private/display_priv.h
+++ b/code/drivers/fpga/private/display_priv.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#define BATTERY_INDICATOR_OUTLINE \
+  (uint64_t)( 0b01110UL << 56u | \
+              0b11111UL << 48u | \
+              0b10001UL << 40u | \
+              0b10001UL << 32u | \
+              0b10001UL << 24u | \
+              0b10001UL << 16u | \
+              0b10001UL << 8u  | \
+              0b11111UL )
+
+#define BATTERY_INDICATOR_EDGE (0b01110)
+
+/**
+ * This just creates a single vertical line down the left side.  To adjust the position,
+ * right shift up to 4.  To create a solid block, OR the result in a loop
+ */
+#define PRESSURE_BAR_EDGE \
+  (uint64_t)( 0b10000UL << 56u | \
+              0b10000UL << 48u | \
+              0b10000UL << 40u | \
+              0b10000UL << 32u | \
+              0b10000UL << 24u | \
+              0b10000UL << 16u | \
+              0b10000UL << 8u  | \
+              0b10000UL )
+
+#define FULL_BLOCK (219u)
+
+enum display_index
+{
+  // TOP LINE
+  DISP_TIDAL_VOL          = 0,
+  DISP_TIDAL_VOL_LEN        = 3,
+  DISP_PEAK_FLOW          = 4,
+  DISP_PEAK_FLOW_LEN        = 4,
+  DISP_RESP_RATE          = 9,
+  DISP_RESP_RATE_LEN        = 2,
+  DISP_PERCENT_O2         = 12,
+  DISP_PERCENT_LEN          = 3,
+  DISP_BATTERY            = 15,
+  DISP_BATTERY_LEN          = 1,
+  // BOTTOM LINE
+  DISP_PRESSURE           = 16,
+  DISP_PRESSURE_LEN         = 2,
+  DISP_PRESSURE_GAUGE     = 18,
+  DISP_PRESSURE_GAUGE_LEN = 14,
+
+  DISP_LEN                = 32
+};
+
+#define PRESSURE_BAR_MMH2O_MAX      (450u)
+#define PRESSURE_BAR_SUB_INCREMENTS (3u) // line left, line centre, line right
+#define PRESSURE_BAR_INCREMENTS     (DISP_PRESSURE_GAUGE_LEN * PRESSURE_BAR_SUB_INCREMENTS)
+#define PRESSURE_BAR_MMH2O_INC      (PRESSURE_BAR_MMH2O_MAX / PRESSURE_BAR_INCREMENTS)
+
+/**
+ * These are the character addresses in the display for the custom characters.
+ * Use these as the ascii code, e.g. (char)CUSTOM_CHAR_PRESSURE_BAR_EDGE.
+ */
+enum custom_char
+{
+  CUSTOM_CHAR_BATTERY_INDICATOR = 0,
+  CUSTOM_CHAR_PRESSURE_BAR_EDGE = 1,
+  CUSTOM_CHAR_PRESSURE_BAR_PEAK = 2,
+  CUSTOM_CHAR_COUNT
+};
+
+/**
+ * Createable custom character definitions
+ *
+ */
+enum display_char
+{
+  DISPLAY_CHAR_PEAK_PRESSURE_0, // Single vertical line to right
+  DISPLAY_CHAR_PEAK_PRESSURE_1, // Single vertical line to left
+  DISPLAY_CHAR_PEAK_PRESSURE_2, // Single vertical line in centre
+  DISPLAY_CHAR_PEAK_PRESSURE_3, // Single vertical line to right
+  DISPLAY_CHAR_PRESSURE_0,      // INVALID
+  DISPLAY_CHAR_PRESSURE_1,      // Single vertical line to left
+  DISPLAY_CHAR_PRESSURE_2,      // Half-width block to left
+  DISPLAY_CHAR_PRESSURE_3,      // Full block
+  DISPLAY_CHAR_BATTERY_0,       // Empty battery outline
+  DISPLAY_CHAR_BATTERY_20,      // Partly filled battery outline
+  DISPLAY_CHAR_BATTERY_40,      // Partly filled battery outline
+  DISPLAY_CHAR_BATTERY_60,      // Partly filled battery outline
+  DISPLAY_CHAR_BATTERY_80,      // Partly filled battery outline
+  DISPLAY_CHAR_BATTERY_100      // Full battery outline
+};

--- a/code/drivers/misc/error.h
+++ b/code/drivers/misc/error.h
@@ -1,0 +1,14 @@
+#ifndef ERROR_H
+#define ERROR_H
+
+#include <stdint.h>
+
+typedef enum
+{
+  ERR_NONE      = 0,
+  ERR_IO        = 1,
+  ERR_BUSY      = 2,
+  ERR_NOT_IMPL  = 3,
+} Error_t;
+
+#endif /* ERROR_H */

--- a/code/drivers/misc/result.h
+++ b/code/drivers/misc/result.h
@@ -1,0 +1,17 @@
+#ifndef RESULT_H
+#define RESULT_H
+
+#include "error.h"
+#include <stdint.h>
+
+typedef struct
+{
+  Error_t err;
+  union value
+  {
+    uint32_t u32_val;
+    int32_t s32_val;
+  } val;
+} Result_t;
+
+#endif /* RESULT_H */

--- a/code/drivers/misc/util.h
+++ b/code/drivers/misc/util.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifndef UTEST_MODE
+#define TESTABLE static
+#else
+#define TESTABLE
+#endif

--- a/unittests/display/CMakeLists.txt
+++ b/unittests/display/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(display_unittest)
+
+include(../unittests_common.cmake)
+
+enable_testing()
+
+add_executable(display_unittest
+  ${UNITY_SRC}
+  ${CODE}/drivers/fpga/display.c
+  display_unittest.c
+  all_tests.c
+)
+
+target_compile_definitions(display_unittest
+  PRIVATE
+)
+
+add_test(NAME display_unittest COMMAND display_unittest -v)

--- a/unittests/display/all_tests.c
+++ b/unittests/display/all_tests.c
@@ -1,0 +1,55 @@
+#include "unity.h"
+#include "unity_fixture.h"
+
+TEST_GROUP_RUNNER(display_tests)
+{
+  RUN_TEST_CASE(display_tests, has_changed_true);
+  RUN_TEST_CASE(display_tests, has_changed_false);
+
+  RUN_TEST_CASE(display_tests, get_copies_custom_chars);
+  RUN_TEST_CASE(display_tests, get_with_null_pointer);
+
+  RUN_TEST_CASE(display_tests, make_custom_char_pressure_peak_marker);
+  RUN_TEST_CASE(display_tests, make_custom_char_pressure_bar_edge);
+  RUN_TEST_CASE(display_tests, make_custom_char_battery_empty);
+  RUN_TEST_CASE(display_tests, make_custom_char_battery);
+
+  RUN_TEST_CASE(display_tests, format_tidal_volume_text);
+  RUN_TEST_CASE(display_tests, format_tidal_volume_out_of_bounds);
+  RUN_TEST_CASE(display_tests, format_tidal_volume_text_no_change);
+
+  RUN_TEST_CASE(display_tests, format_peak_flow_text);
+  RUN_TEST_CASE(display_tests, format_peak_flow_out_of_bounds);
+  RUN_TEST_CASE(display_tests, format_peak_flow_text_no_change);
+
+  RUN_TEST_CASE(display_tests, format_respiration_rate_text);
+  RUN_TEST_CASE(display_tests, format_respiration_rate_out_of_bounds);
+  RUN_TEST_CASE(display_tests, format_respiration_rate_text_no_change);
+
+  RUN_TEST_CASE(display_tests, format_percent_o2_text);
+  RUN_TEST_CASE(display_tests, format_percent_o2_out_of_bounds);
+  RUN_TEST_CASE(display_tests, format_percent_o2_text_no_change);
+
+  RUN_TEST_CASE(display_tests, format_pressure_text);
+  RUN_TEST_CASE(display_tests, format_pressure_text_out_of_bounds);
+  RUN_TEST_CASE(display_tests, format_pressure_text_no_change);
+
+  RUN_TEST_CASE(display_tests, format_pressure_bar_rising);
+  RUN_TEST_CASE(display_tests, format_pressure_bar_falling);
+  RUN_TEST_CASE(display_tests, format_pressure_bar_edge_chars);
+  RUN_TEST_CASE(display_tests, format_pressure_bar_overlapping_edge_chars);
+  RUN_TEST_CASE(display_tests, format_pressure_bar_out_of_bounds);
+
+  RUN_TEST_CASE(display_tests, format_battery_gauge_char);
+  RUN_TEST_CASE(display_tests, format_battery_gauge_char_no_change);
+}
+
+static void RunAllTests(void)
+{
+  RUN_TEST_GROUP(display_tests);
+}
+
+int main(int argc, const char* argv[])
+{
+  return UnityMain(argc, argv, RunAllTests);
+}

--- a/unittests/display/display_unittest.c
+++ b/unittests/display/display_unittest.c
@@ -1,0 +1,482 @@
+#include "unity.h"
+#include "unity_fixture.h"
+#include "fpga/display.h"
+#include "fpga/private/display_priv.h"
+#include <string.h>
+
+extern uint64_t s_custom_chars[CUSTOM_CHAR_COUNT];
+extern char s_display[DISP_LEN];
+extern bool s_display_changed;
+
+extern void make_custom_char(enum display_char char_to_create);
+
+TEST_GROUP(display_tests);
+
+TEST_SETUP(display_tests)
+{
+  memset(s_custom_chars, 0u, sizeof(s_custom_chars));
+  memset(s_display, ' ', sizeof(s_display));
+  s_display_changed = false;
+}
+
+TEST_TEAR_DOWN(display_tests)
+{}
+
+TEST(display_tests, has_changed_true)
+{
+  s_display_changed = true;
+  TEST_ASSERT_TRUE(display_has_changed());
+}
+
+TEST(display_tests, has_changed_false)
+{
+  TEST_ASSERT_FALSE(display_has_changed());
+}
+
+TEST(display_tests, get_copies_custom_chars)
+{
+  message_mcu_to_fpga_t message;
+  memset(&message, 0xFF, sizeof(message));
+
+  s_display_changed = true;
+  display_get(&message);
+
+  TEST_ASSERT_EQUAL_UINT64(0u, message.battery_indicator);
+  TEST_ASSERT_EQUAL_UINT64(0u, message.pressure_bar_edge);
+  TEST_ASSERT_EQUAL_UINT64(0u, message.pressure_bar_peak);
+
+  TEST_ASSERT_FALSE(s_display_changed);
+}
+
+TEST(display_tests, get_with_null_pointer)
+{
+  s_display_changed = true;
+  display_get((message_mcu_to_fpga_t*)0u);
+
+  TEST_ASSERT_TRUE(s_display_changed);
+}
+
+TEST(display_tests, make_custom_char_pressure_peak_marker)
+{
+  make_custom_char(DISPLAY_CHAR_PEAK_PRESSURE_0);
+  TEST_ASSERT_EQUAL_UINT64(0x0101010101010101,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK]);
+
+  make_custom_char(DISPLAY_CHAR_PEAK_PRESSURE_1);
+  TEST_ASSERT_EQUAL_UINT64(0x1010101010101010,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK]);
+
+  make_custom_char(DISPLAY_CHAR_PEAK_PRESSURE_2);
+  TEST_ASSERT_EQUAL_UINT64(0x0404040404040404,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK]);
+
+  make_custom_char(DISPLAY_CHAR_PEAK_PRESSURE_3);
+  TEST_ASSERT_EQUAL_UINT64(0x0101010101010101,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK]);
+
+  // Check others characters are unmodified
+  TEST_ASSERT_EQUAL_UINT64(0u,
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+  TEST_ASSERT_EQUAL_UINT64(0u,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE]);
+}
+
+TEST(display_tests, make_custom_char_pressure_bar_edge)
+{
+  // Invalid
+  make_custom_char(DISPLAY_CHAR_PRESSURE_0);
+  TEST_ASSERT_EQUAL_UINT64(0u,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE]);
+
+  make_custom_char(DISPLAY_CHAR_PRESSURE_1);
+  TEST_ASSERT_EQUAL_UINT64(0x1010101010101010,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE]);
+
+  make_custom_char(DISPLAY_CHAR_PRESSURE_2);
+  TEST_ASSERT_EQUAL_UINT64(0x1C1C1C1C1C1C1C1C,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE]);
+
+  make_custom_char(DISPLAY_CHAR_PRESSURE_3);
+  TEST_ASSERT_EQUAL_UINT64(0x1F1F1F1F1F1F1F1F,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE]);
+
+  // Check others characters are unmodified
+  TEST_ASSERT_EQUAL_UINT64(0u,
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+  TEST_ASSERT_EQUAL_UINT64(0u,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK]);
+}
+
+TEST(display_tests, make_custom_char_battery_empty)
+{
+  make_custom_char(DISPLAY_CHAR_BATTERY_0);
+  TEST_ASSERT_EQUAL_UINT64(BATTERY_INDICATOR_OUTLINE,
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  // Check others characters are unmodified
+  TEST_ASSERT_EQUAL_UINT64(0u,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE]);
+  TEST_ASSERT_EQUAL_UINT64(0u,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK]);
+}
+
+TEST(display_tests, make_custom_char_battery)
+{
+  make_custom_char(DISPLAY_CHAR_BATTERY_20);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  make_custom_char(DISPLAY_CHAR_BATTERY_40);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE0E00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  make_custom_char(DISPLAY_CHAR_BATTERY_60);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE0E0E00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  make_custom_char(DISPLAY_CHAR_BATTERY_80);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE0E0E0E00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  make_custom_char(DISPLAY_CHAR_BATTERY_100);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE0E0E0E0E00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  // Check others characters are unmodified
+  TEST_ASSERT_EQUAL_UINT64(0u,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE]);
+  TEST_ASSERT_EQUAL_UINT64(0u,
+    s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK]);
+}
+
+TEST(display_tests, format_tidal_volume_text)
+{
+  char expected1[DISP_TIDAL_VOL_LEN] = {'0', '0', '9'};
+  display_format_tidal_volume(9u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected1, &s_display[DISP_TIDAL_VOL], DISP_TIDAL_VOL_LEN);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  char expected2[DISP_TIDAL_VOL_LEN] = {'1', '2', '3'};
+  display_format_tidal_volume(123u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected2, &s_display[DISP_TIDAL_VOL], DISP_TIDAL_VOL_LEN);
+}
+
+TEST(display_tests, format_tidal_volume_out_of_bounds)
+{
+  char expected[DISP_TIDAL_VOL_LEN] = {'>', '1', 'k'};
+  display_format_tidal_volume(9999u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_TIDAL_VOL], DISP_TIDAL_VOL_LEN);
+  TEST_ASSERT_TRUE(display_has_changed());
+}
+
+TEST(display_tests, format_tidal_volume_text_no_change)
+{
+  message_mcu_to_fpga_t message;
+
+  display_format_tidal_volume(50u);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  display_get(&message);
+  TEST_ASSERT_FALSE(display_has_changed());
+
+  display_format_tidal_volume(50u);
+  TEST_ASSERT_FALSE(display_has_changed());
+}
+
+TEST(display_tests, format_peak_flow_text)
+{
+  // Argument is in ml/s and output is in l/min.  9.6 l/min == 160 ml/s
+  char expected1[DISP_PEAK_FLOW_LEN] = {'0', '9', '.', '6'};
+  display_format_peak_flow(160u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected1, &s_display[DISP_PEAK_FLOW],
+    DISP_PEAK_FLOW_LEN);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  // Argument is in ml/s and output is in l/min.  34.2 l/min == 570 ml/s
+  char expected2[DISP_PEAK_FLOW_LEN] = {'3', '4', '.', '2'};
+  display_format_peak_flow(570u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected2, &s_display[DISP_PEAK_FLOW],
+    DISP_PEAK_FLOW_LEN);
+}
+
+TEST(display_tests, format_peak_flow_out_of_bounds)
+{
+  // Argument is in ml/s and output is in l/min.  100 l/min == 1667 ml/s
+  char expected[DISP_PEAK_FLOW_LEN] = {'>', '1', '0', '0'};
+  display_format_peak_flow(1667u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PEAK_FLOW],
+    DISP_PEAK_FLOW_LEN);
+  TEST_ASSERT_TRUE(display_has_changed());
+}
+
+TEST(display_tests, format_peak_flow_text_no_change)
+{
+  message_mcu_to_fpga_t message;
+
+  display_format_peak_flow(50u);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  display_get(&message);
+  TEST_ASSERT_FALSE(display_has_changed());
+
+  display_format_peak_flow(50u);
+  TEST_ASSERT_FALSE(display_has_changed());
+}
+
+TEST(display_tests, format_respiration_rate_text)
+{
+  char resp_rate_expected1[DISP_RESP_RATE_LEN] = {'0', '9'};
+  display_format_respiration_rate(9u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(resp_rate_expected1, &s_display[DISP_RESP_RATE], DISP_RESP_RATE_LEN);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  char resp_rate_expected2[DISP_RESP_RATE_LEN] = {'1', '2'};
+  display_format_respiration_rate(12u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(resp_rate_expected2, &s_display[DISP_RESP_RATE], DISP_RESP_RATE_LEN);
+}
+
+TEST(display_tests, format_respiration_rate_out_of_bounds)
+{
+  char resp_rate_expected[DISP_RESP_RATE_LEN] = {'?', '?'};
+  display_format_respiration_rate(UINT8_MAX);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(resp_rate_expected, &s_display[DISP_RESP_RATE], DISP_RESP_RATE_LEN);
+  TEST_ASSERT_TRUE(display_has_changed());
+}
+
+TEST(display_tests, format_respiration_rate_text_no_change)
+{
+  message_mcu_to_fpga_t message;
+
+  display_format_respiration_rate(50u);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  display_get(&message);
+  TEST_ASSERT_FALSE(display_has_changed());
+
+  display_format_respiration_rate(50u);
+  TEST_ASSERT_FALSE(display_has_changed());
+}
+
+TEST(display_tests, format_percent_o2_text)
+{
+  char percent_expected1[DISP_PERCENT_LEN] = {'0', '0', '9'};
+  display_format_percent_o2(9u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(percent_expected1, &s_display[DISP_PERCENT_O2], DISP_PERCENT_LEN);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  char percent_expected2[DISP_PERCENT_LEN] = {'1', '0', '0'};
+  display_format_percent_o2(100u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(percent_expected2, &s_display[DISP_PERCENT_O2], DISP_PERCENT_LEN);
+}
+
+TEST(display_tests, format_percent_o2_out_of_bounds)
+{
+  // Display should cap at 100%
+  char percent_expected[DISP_PERCENT_LEN] = {'1', '0', '0'};
+  display_format_percent_o2(UINT8_MAX);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(percent_expected, &s_display[DISP_PERCENT_O2], DISP_PERCENT_LEN);
+  TEST_ASSERT_TRUE(display_has_changed());
+}
+
+TEST(display_tests, format_percent_o2_text_no_change)
+{
+  message_mcu_to_fpga_t message;
+
+  display_format_percent_o2(50u);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  display_get(&message);
+  TEST_ASSERT_FALSE(display_has_changed());
+
+  display_format_percent_o2(50u);
+  TEST_ASSERT_FALSE(display_has_changed());
+}
+
+TEST(display_tests, format_pressure_text)
+{
+  char pressure_expected1[DISP_PRESSURE_LEN] = {'0', '9'};
+  display_format_pressure_bar(9u, 0u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(pressure_expected1, &s_display[DISP_PRESSURE], DISP_PRESSURE_LEN);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  char pressure_expected2[DISP_PRESSURE_LEN] = {'1', '2'};
+  display_format_pressure_bar(12u, 0u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(pressure_expected2, &s_display[DISP_PRESSURE], DISP_PRESSURE_LEN);
+}
+
+TEST(display_tests, format_pressure_text_out_of_bounds)
+{
+  char pressure_expected[DISP_PRESSURE_LEN] = {'?', '?'};
+  display_format_pressure_bar(100u, 0u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(pressure_expected, &s_display[DISP_PRESSURE], DISP_PRESSURE_LEN);
+  TEST_ASSERT_TRUE(display_has_changed());
+}
+
+TEST(display_tests, format_pressure_text_no_change)
+{
+  message_mcu_to_fpga_t message;
+
+  display_format_pressure_bar(50u, 50u);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  display_get(&message);
+  TEST_ASSERT_FALSE(display_has_changed());
+
+  display_format_pressure_bar(50u, 50u);
+  TEST_ASSERT_FALSE(display_has_changed());
+}
+
+TEST(display_tests, format_pressure_bar_rising)
+{
+  char expected[DISP_PRESSURE_GAUGE_LEN] =
+    {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',  ' '};
+
+  display_format_pressure_bar(0u, 0u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+
+  expected[0] = FULL_BLOCK;
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 3u), 0u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+
+  expected[1] = FULL_BLOCK;
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 6u), 0u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+
+  expected[2] = FULL_BLOCK;
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 9u), 0u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+}
+
+TEST(display_tests, format_pressure_bar_falling)
+{
+  char expected[DISP_PRESSURE_GAUGE_LEN] =
+  {
+    FULL_BLOCK, FULL_BLOCK, FULL_BLOCK,
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+    CUSTOM_CHAR_PRESSURE_BAR_PEAK
+  };
+
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 9u), PRESSURE_BAR_MMH2O_MAX);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+
+  expected[2] = ' ';
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 6u), PRESSURE_BAR_MMH2O_MAX);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+
+  expected[1] = ' ';
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 3u), PRESSURE_BAR_MMH2O_MAX);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+
+  expected[0] = ' ';
+  display_format_pressure_bar(0u, PRESSURE_BAR_MMH2O_MAX);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+}
+
+TEST(display_tests, format_pressure_bar_edge_chars)
+{
+  char expected[DISP_PRESSURE_GAUGE_LEN] =
+  {
+    FULL_BLOCK,
+    CUSTOM_CHAR_PRESSURE_BAR_EDGE,
+    CUSTOM_CHAR_PRESSURE_BAR_PEAK,
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '
+  };
+
+  make_custom_char(DISPLAY_CHAR_PRESSURE_1);
+  make_custom_char(DISPLAY_CHAR_PEAK_PRESSURE_2);
+
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 4u), (PRESSURE_BAR_MMH2O_INC * 8u));
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+
+  // Check the characters have *not* been combined
+  TEST_ASSERT_EQUAL_UINT64(0x1010101010101010, s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE]);
+  TEST_ASSERT_EQUAL_UINT64(0x0404040404040404, s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_PEAK]);
+}
+
+TEST(display_tests, format_pressure_bar_overlapping_edge_chars)
+{
+  char expected[DISP_PRESSURE_GAUGE_LEN] =
+  {
+    FULL_BLOCK, FULL_BLOCK,
+    CUSTOM_CHAR_PRESSURE_BAR_EDGE,
+    ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '
+  };
+
+  make_custom_char(DISPLAY_CHAR_PRESSURE_1);
+  make_custom_char(DISPLAY_CHAR_PEAK_PRESSURE_2);
+
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 7u), (PRESSURE_BAR_MMH2O_INC * 8u));
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+
+  // Check the characters have been combined
+  TEST_ASSERT_EQUAL_UINT64(0x1414141414141414, s_custom_chars[CUSTOM_CHAR_PRESSURE_BAR_EDGE]);
+}
+
+TEST(display_tests, format_pressure_bar_out_of_bounds)
+{
+  char expected[DISP_PRESSURE_GAUGE_LEN] =
+  {
+    FULL_BLOCK, FULL_BLOCK, FULL_BLOCK, FULL_BLOCK,
+    FULL_BLOCK, FULL_BLOCK, FULL_BLOCK, FULL_BLOCK,
+    FULL_BLOCK, FULL_BLOCK, FULL_BLOCK, FULL_BLOCK,
+    FULL_BLOCK, FULL_BLOCK
+  };
+
+  display_format_pressure_bar(UINT16_MAX, 0u);
+  TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
+}
+
+TEST(display_tests, format_battery_gauge_char)
+{
+  display_format_battery_gauge(0u);
+  TEST_ASSERT_EQUAL_UINT64(BATTERY_INDICATOR_OUTLINE,
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  display_format_battery_gauge(255u);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE0E0E0E0E00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  display_format_battery_gauge(5u);
+  TEST_ASSERT_EQUAL_UINT64(BATTERY_INDICATOR_OUTLINE,
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  display_format_battery_gauge(20u);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  display_format_battery_gauge(40u);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE0E00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  display_format_battery_gauge(60u);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE0E0E00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  display_format_battery_gauge(80u);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE0E0E0E00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  display_format_battery_gauge(100u);
+  TEST_ASSERT_EQUAL_UINT64((BATTERY_INDICATOR_OUTLINE | 0xE0E0E0E0E00),
+    s_custom_chars[CUSTOM_CHAR_BATTERY_INDICATOR]);
+
+  // Ensure the battery character is inserted into the cached display
+  TEST_ASSERT_EQUAL_CHAR(CUSTOM_CHAR_BATTERY_INDICATOR, s_display[DISP_BATTERY]);
+}
+
+TEST(display_tests, format_battery_gauge_char_no_change)
+{
+  message_mcu_to_fpga_t message;
+
+  display_format_battery_gauge(1u);
+  TEST_ASSERT_TRUE(display_has_changed());
+
+  display_get(&message);
+  TEST_ASSERT_FALSE(display_has_changed());
+
+  display_format_battery_gauge(1u);
+  TEST_ASSERT_FALSE(display_has_changed());
+
+  // Ensure the battery character is inserted into the cached display
+  TEST_ASSERT_EQUAL_CHAR(CUSTOM_CHAR_BATTERY_INDICATOR, s_display[DISP_BATTERY]);
+}

--- a/unittests/display/display_unittest.c
+++ b/unittests/display/display_unittest.c
@@ -185,16 +185,16 @@ TEST(display_tests, format_tidal_volume_text_no_change)
 
 TEST(display_tests, format_peak_flow_text)
 {
-  // Argument is in ml/s and output is in l/min.  9.6 l/min == 160 ml/s
+  // Argument is in dl/min and output is in l/min.  9.6 l/min == 96 dl/min
   char expected1[DISP_PEAK_FLOW_LEN] = {'0', '9', '.', '6'};
-  display_format_peak_flow(160u);
+  display_format_peak_flow(96u);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected1, &s_display[DISP_PEAK_FLOW],
     DISP_PEAK_FLOW_LEN);
   TEST_ASSERT_TRUE(display_has_changed());
 
-  // Argument is in ml/s and output is in l/min.  34.2 l/min == 570 ml/s
+  // Argument is in dl/min and output is in l/min.  34.2 l/min == 342 dl/min
   char expected2[DISP_PEAK_FLOW_LEN] = {'3', '4', '.', '2'};
-  display_format_peak_flow(570u);
+  display_format_peak_flow(342u);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected2, &s_display[DISP_PEAK_FLOW],
     DISP_PEAK_FLOW_LEN);
 }
@@ -237,7 +237,7 @@ TEST(display_tests, format_respiration_rate_text)
 
 TEST(display_tests, format_respiration_rate_out_of_bounds)
 {
-  char resp_rate_expected[DISP_RESP_RATE_LEN] = {'?', '?'};
+  char resp_rate_expected[DISP_RESP_RATE_LEN] = {'-', '-'};
   display_format_respiration_rate(UINT8_MAX);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(resp_rate_expected, &s_display[DISP_RESP_RATE], DISP_RESP_RATE_LEN);
   TEST_ASSERT_TRUE(display_has_changed());
@@ -306,7 +306,7 @@ TEST(display_tests, format_pressure_text)
 
 TEST(display_tests, format_pressure_text_out_of_bounds)
 {
-  char pressure_expected[DISP_PRESSURE_LEN] = {'?', '?'};
+  char pressure_expected[DISP_PRESSURE_LEN] = {'-', '-'};
   display_format_pressure_bar(100u, 0u);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(pressure_expected, &s_display[DISP_PRESSURE], DISP_PRESSURE_LEN);
   TEST_ASSERT_TRUE(display_has_changed());
@@ -335,15 +335,15 @@ TEST(display_tests, format_pressure_bar_rising)
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
 
   expected[0] = FULL_BLOCK;
-  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 3u), 0u);
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 3u) / 10u, 0u);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
 
   expected[1] = FULL_BLOCK;
-  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 6u), 0u);
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 6u) / 10u, 0u);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
 
   expected[2] = FULL_BLOCK;
-  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 9u), 0u);
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 9u) / 10u, 0u);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
 }
 
@@ -356,15 +356,15 @@ TEST(display_tests, format_pressure_bar_falling)
     CUSTOM_CHAR_PRESSURE_BAR_PEAK
   };
 
-  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 9u), PRESSURE_BAR_MMH2O_MAX);
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 9u) / 10u, PRESSURE_BAR_MMH2O_MAX);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
 
   expected[2] = ' ';
-  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 6u), PRESSURE_BAR_MMH2O_MAX);
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 6u) / 10u, PRESSURE_BAR_MMH2O_MAX);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
 
   expected[1] = ' ';
-  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 3u), PRESSURE_BAR_MMH2O_MAX);
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 3u) / 10u, PRESSURE_BAR_MMH2O_MAX);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
 
   expected[0] = ' ';
@@ -385,7 +385,8 @@ TEST(display_tests, format_pressure_bar_edge_chars)
   make_custom_char(DISPLAY_CHAR_PRESSURE_1);
   make_custom_char(DISPLAY_CHAR_PEAK_PRESSURE_2);
 
-  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 4u), (PRESSURE_BAR_MMH2O_INC * 8u));
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 4u) / 10u,
+    (PRESSURE_BAR_MMH2O_INC * 8u) / 10u);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
 
   // Check the characters have *not* been combined
@@ -405,7 +406,8 @@ TEST(display_tests, format_pressure_bar_overlapping_edge_chars)
   make_custom_char(DISPLAY_CHAR_PRESSURE_1);
   make_custom_char(DISPLAY_CHAR_PEAK_PRESSURE_2);
 
-  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 7u), (PRESSURE_BAR_MMH2O_INC * 8u));
+  display_format_pressure_bar((PRESSURE_BAR_MMH2O_INC * 7u) / 10u,
+    (PRESSURE_BAR_MMH2O_INC * 8u) / 10u);
   TEST_ASSERT_EQUAL_CHAR_ARRAY(expected, &s_display[DISP_PRESSURE_GAUGE], DISP_PRESSURE_GAUGE_LEN);
 
   // Check the characters have been combined

--- a/unittests/unittests_common.cmake
+++ b/unittests/unittests_common.cmake
@@ -6,6 +6,8 @@ set(UNITY_SRC
   ../frameworks/Unity/extras/memory/src/unity_memory.c
 )
 
+set(CODE ../../code)
+
 add_definitions(
     -DDEBUG
     -DUTEST_MODE
@@ -17,7 +19,7 @@ include_directories(
   ../frameworks/Unity/extras/fixture/src
   ../frameworks/Unity/extras/memory/src
   ../mocks
-  ../../code/application
-  ../../code/drivers
-  ../../code/hal
+  ${CODE}/application
+  ${CODE}/drivers
+  ${CODE}/hal
 )


### PR DESCRIPTION
```
Unity test run 1 of 1
TEST(display_tests, has_changed_true) PASS
TEST(display_tests, has_changed_false) PASS
TEST(display_tests, get_copies_custom_chars) PASS
TEST(display_tests, get_with_null_pointer) PASS
TEST(display_tests, make_custom_char_pressure_peak_marker) PASS
TEST(display_tests, make_custom_char_pressure_bar_edge) PASS
TEST(display_tests, make_custom_char_battery_empty) PASS
TEST(display_tests, make_custom_char_battery) PASS
TEST(display_tests, format_tidal_volume_text) PASS
TEST(display_tests, format_tidal_volume_out_of_bounds) PASS
TEST(display_tests, format_tidal_volume_text_no_change) PASS
TEST(display_tests, format_peak_flow_text) PASS
TEST(display_tests, format_peak_flow_out_of_bounds) PASS
TEST(display_tests, format_peak_flow_text_no_change) PASS
TEST(display_tests, format_respiration_rate_text) PASS
TEST(display_tests, format_respiration_rate_out_of_bounds) PASS
TEST(display_tests, format_respiration_rate_text_no_change) PASS
TEST(display_tests, format_percent_o2_text) PASS
TEST(display_tests, format_percent_o2_out_of_bounds) PASS
TEST(display_tests, format_percent_o2_text_no_change) PASS
TEST(display_tests, format_pressure_text) PASS
TEST(display_tests, format_pressure_text_out_of_bounds) PASS
TEST(display_tests, format_pressure_text_no_change) PASS
TEST(display_tests, format_pressure_bar_rising) PASS
TEST(display_tests, format_pressure_bar_falling) PASS
TEST(display_tests, format_pressure_bar_edge_chars) PASS
TEST(display_tests, format_pressure_bar_overlapping_edge_chars) PASS
TEST(display_tests, format_pressure_bar_out_of_bounds) PASS
TEST(display_tests, format_battery_gauge_char) PASS
TEST(display_tests, format_battery_gauge_char_no_change) PASS

-----------------------
30 Tests 0 Failures 0 Ignored 
OK
```